### PR TITLE
Fix database file not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX ?= /usr/local
+PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
 DATADIR ?= $(PREFIX)/share
 MANDIR ?= $(PREFIX)/share/man


### PR DESCRIPTION
When executing it outputs: netbsd-wtf: cannot open acronym database file `/usr/local/share/wtf/acronyms*'
This is temporarily fixed by changing the location of the database file: netbsd-wtf -f '/usr/share/wtf/acronyms*'